### PR TITLE
Use selenium-installed web driver to export plots

### DIFF
--- a/docs/source/applications/ms_raster.rst
+++ b/docs/source/applications/ms_raster.rst
@@ -70,9 +70,11 @@ Construct MsRaster Object
 * ``show_gui`` (bool): whether to launch the interactive GUI in a browser tab.
 
 MsRaster can be constructed with the ``ms`` path to a MSv2 or MSv4 file. If a
-MSv2 path is supplied, it will automatically be converted to the MSv4 zarr
-format in the same directory as the MSv2 with the extension **.ps.zarr**. For
-more information on the MSv4 data format, see the XRADIO
+MSv2 path is supplied and the correct dependencies have been installed
+separately (see :ref:`install_conversion`), the MSv2 will automatically be
+converted to the MSv4 zarr format in the same directory as the MSv2, with the
+extension **.ps.zarr**. For more information on the MSv4 data format, see the
+XRADIO
 `Measurement Set Tutorial <https://xradio.readthedocs.io/en/latest/measurement_set/tutorials/measurement_set_tutorial.html>`_.
 
 .. warning::
@@ -88,7 +90,7 @@ the Python console.  When the ``log_to_file`` option is enabled (default), log
 messages will also be written to the file *msraster-<timestamp>.log* in the
 current directory.
 
-At construction, we decide whether to create the plots using MsRaster functions
+At construction, set whether plots will be constructed using MsRaster functions
 (``showgui=False``) or using the interactive GUI (``showgui=True``).  When the
 GUI is shown, using MsRaster functions does not update the GUI widget selections
 or the plot. The ``ms`` parameter is required when ``showgui=False``, but
@@ -497,22 +499,25 @@ After a plot is created (see :ref:`create_plot`), it may be saved to a file with
   as {ms}_raster.{ext}. If fmt is not set, plot will be saved as .png.
 * ``fmt`` (str): Format of file to save ('png', 'html', or 'gif'). Default
   'auto': inferred from filename extension.
-* ``width`` (int): width of exported plot.
-* ``height`` (int): height of exported plot.
+* ``width`` (int): width of exported plot in pixels.
+* ``height`` (int): height of exported plot in pixels.
 
 As in :ref:`show_plot`, multiple plots can be saved in a layout using the
-``subplots`` parameter in the :ref:`create_plot` ``plot()`` function. This
-layout plot will be saved to a single file with ``filename``.
+``subplots`` parameter in the :ref:`create_plot` ``plot()`` function. Each plot
+in the layout will have size *(width, height)* resulting in a layout plot of
+size *(width * columns, height * rows)* pixels. This layout plot is saved to a
+single file with ``filename``.
 
 However, if iteration plots were created and ``subplots`` is a single plot
 (None or (1, 1)), the iteration plots will be saved individually with a plot
 index appended to the filename according to the ``iter_range`` index range:
-{``filename``}_{index}.{ext}.
+*{filename}_{index}.{ext}*.
 
 When ``save()`` is called, as with ``show()`` the plot is exported to an HTML
-file. If the file format is .png, the exported plot will be rendered as a
-PNG, which currently requires Selenium and either firefox and geckodriver
-or chromium browser and chromedriver (see :ref:`install_msraster`).
+file.  When ``fmt`` is 'png', the plot is rendered in memory then a screenshot is
+captured to create a PNG file. For 'svg' export, Bokeh replaces the HTML5 Canvas
+plot output with a Scalable Vector Graphics (SVG) element that can be edited in
+image editing programs such as Adobe Illustrator and/or converted to PDF.
 
 .. warning::
    If you have rendered the plot with ``show()``, it is much faster to save

--- a/docs/source/applications/overview.rst
+++ b/docs/source/applications/overview.rst
@@ -52,7 +52,7 @@ data I/O, logging, plotting, and interactive dashboards:
   overlay plots
 
 * Holoviz library :xref:`panel` streamlines the development of apps and
-  dashboards for the raster plots
+  dashboards for the plots
 
 Implementation
 --------------
@@ -85,17 +85,15 @@ Requirements
 
 - Python 3.11 or greater
 
-Many packages are automatically installed as ``vidavis`` dependencies,
+The required dependency packages are automatically installed with ``vidavis``,
 including those listed in the :ref:`Infrastructure` section.
 
 Optionally, :xref:`xradio` with
 `python-casacore <https://casacore.github.io/python-casacore/>`_
 or `casatools <https://casadocs.readthedocs.io/en/stable/api/casatools.html>`_
-is required to enable conversion from MSv2 to MSv4. To export plots to file
-using ``save()``, additional packages are required: **geckodriver** for firefox,
-or **chromedriver** for chromium. See below for installation instructions.
+is required to enable conversion from MSv2 to MSv4 in the applications.
 
-.. _install_msraster:
+.. _install_vidavis:
 
 Install vidavis
 ```````````````
@@ -110,6 +108,8 @@ self-contained runtime where vidavis and its dependencies can be installed::
 Install required packages::
 
   pip install vidavis
+
+.. _install_conversion:
 
 Install for MSv2 Conversion
 ```````````````````````````
@@ -127,33 +127,6 @@ It is also possible to use
 as the backend for reading the MSv2. See the
 `XRADIO casatools setup guide <https://xradio.readthedocs.io/en/latest/measurement_set/guides/backends.html>`_
 for more information.
-
-Install for Exporting Plots
-```````````````````````````
-
-Additional packages are required to export plots to file using ``save()`` rather
-than the save tool in the interactive :xref:`bokeh` plots shown in the browser.
-Install `Selenium <https://www.selenium.dev/documentation/en/>`_ along with a
-web driver.
-
-**Choose one**:
-
-**Selenium** with **geckodriver** and **Firefox** (to ensure compatible versions)::
-
-  conda install -c conda-forge selenium firefox geckodriver
-
-**Selenium** with **ChromeDriver** (Chrome), with the executable
-**chromedriver** in your PATH::
-
-  conda install -c conda-forge selenium python-chromedriver-binary
-
-or::
-
-  pip install selenium chromedriver-binary
-
-For more information, see the
-`Bokeh export dependencies <https://docs.bokeh.org/en/3.6.3/docs/user_guide/output/export.html#ug-output-export-dependencies>`_
-documentation.
 
 Dask.distributed Scheduler
 --------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = '2025 Associated Universities, Inc. Washington DC, USA.'
 author = 'CASA visualization team'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = '0.0.6'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,10 +6,11 @@
 Visibility Data Visualization
 =============================
 
-The :code:`vidavis` (VIsibility DAta VISualization) package provides graphical
-user interfaces to replace the :xref:`casa` MeasurementSet visibility plotters.
-This new generation of interfaces, which are implemented in Python, will be
-based on :xref:`bokeh` and will use web browsers for display.
+The :code:`vidavis` (VIsibility DAta VISualization) package provides
+applications with optional graphical user interfaces to replace the :xref:`casa`
+MeasurementSet visibility plotters. This new generation of applications, which
+are implemented in Python, will create plots based on :xref:`bokeh` and will use
+web browsers for display.
 
 There are two basic documentation sections. The primary section describes the
 applications that are provided by :code:`vidavis`. The second section describes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ authors = [
 
 dependencies = [
     "bokeh==3.6.1",
+    "matplotlib",
     "hvplot",
     "graphviper",
+    "selenium"
 ]
 requires-python = ">=3.11, <3.14"
 readme = "readme.rst"

--- a/readme.rst
+++ b/readme.rst
@@ -34,9 +34,6 @@ Requirements
 - Optionally `python-casacore <https://pypi.org/project/python-casacore/>`_ or
   `casatools <https://pypi.org/project/casatools/>`_ for MSv2 conversion
 
-- Optionally `Selenium <https://www.selenium.dev/documentation/en/>`_ along with
-  a web driver to export to file using ``save()``
-
 Install
 ```````
 
@@ -52,25 +49,6 @@ To enable conversion from MSv2 to MSv4 with **python-casacore** use (this only w
 On macOS it is required to pre-install `python-casacore` using:
 
 - :code:`conda install -c conda-forge python-casacore`
-
-Exporting Plots
-^^^^^^^^^^^^^^^
-
-To enable exporting plots to file without showing the plot, using preferred web
-driver:
-
-**Selenium** with **geckodriver** and **Firefox** (to ensure compatible versions):
-
-- :code:`conda install -c conda-forge selenium firefox geckodriver`
-
-**Selenium** with **ChromeDriver** (Chrome), with the executable
-**chromedriver** in your PATH:
-
-- :code:`conda install -c conda-forge selenium python-chromedriver-binary`
-
-or:
-
-- :code:`pip install selenium chromedriver-binary`
 
 Simple MsRaster Usage Example
 `````````````````````````````

--- a/src/vidavis/apps/_ms_raster.py
+++ b/src/vidavis/apps/_ms_raster.py
@@ -244,10 +244,13 @@ class MsRaster(MsPlot):
         Args:
             filename (str): Name of file to save. Default '': the plot will be saved as {ms}_raster.{ext}.
                 If fmt is not set for extension, plot will be saved as .png.
-            fmt (str): Format of file to save ('png', 'html', or 'gif').
+            fmt (str): Format of file to save ('png', 'svg', or 'html').
                 Default 'auto': inferred from filename extension.
-            width (int): width of exported plot.
-            height (int): height of exported plot.
+            width (int): width of exported plot in pixels.
+            height (int): height of exported plot in pixels.
+
+        If subplots defines a grid layout, width and height describe the size of each plot in the layout.
+            The layout plot size will be (width * columns, height * rows) pixels.
 
         If iteration plots were created:
             If subplots is a grid, the layout plot will be saved to a single file.

--- a/src/vidavis/plot/ms_plot/_ms_plot.py
+++ b/src/vidavis/plot/ms_plot/_ms_plot.py
@@ -11,7 +11,6 @@ import hvplot
 import holoviews as hv
 import numpy as np
 import panel as pn
-#import pdb
 from selenium import webdriver
 
 try:
@@ -223,8 +222,8 @@ class MsPlot:
 
         try:
             hvplot.save(plot, filename=filename, fmt=fmt)
-        except RuntimeError as exc:
-            # Fails if hvplot cannot find web driver.
+        except (Exception, RuntimeError) as exc:
+            # Fails if hvplot cannot find web driver or fmt is svg.
             # Render a Bokeh Figure or GridPlot, create webdriver, then use Bokeh to export.
             fig = hv.render(plot)
             if fmt=='html':


### PR DESCRIPTION
Remove user-installed web driver and use selenium instead.  This enables the package to be ready to use when installed with pip.

Set fixed size in a plot, or in each plot in a layout, for proper rendering using web driver.